### PR TITLE
Remove pytorch dependency

### DIFF
--- a/torchshow/utils.py
+++ b/torchshow/utils.py
@@ -1,6 +1,4 @@
 import numpy as np
-import torch
-
 
 def isinteger(x):
     """
@@ -40,9 +38,15 @@ def calculate_grid_layout(N, img_H, img_W, nrow=None, ncol=None):
     
 def tensor_to_array(x):
     # Recursively perform tensor to array conversion
-    if isinstance(x, torch.Tensor):
-        return x.detach().clone().cpu().numpy()
-    elif isinstance(x, np.ndarray):
+    try:
+        import torch # If torch is not install. We will not handle torch tensors.
+    except ImportError:
+        pass
+    else:
+        if isinstance(x, torch.Tensor):
+            return x.detach().clone().cpu().numpy()
+        
+    if isinstance(x, np.ndarray):
         return x.copy()
     elif isinstance(x, list):
         return [tensor_to_array(e) for e in x]

--- a/torchshow/utils.py
+++ b/torchshow/utils.py
@@ -39,7 +39,7 @@ def calculate_grid_layout(N, img_H, img_W, nrow=None, ncol=None):
 def tensor_to_array(x):
     # Recursively perform tensor to array conversion
     try:
-        import torch # If torch is not install. We will not handle torch tensors.
+        import torch # If PyTorch is not installed, TorchShow will not handle torch tensors.
     except ImportError:
         pass
     else:


### PR DESCRIPTION
Currently the only two necessary dependencies of TorchShow are `numpy` and `matplotlib`. However, in `utils.py` we import `torch` which is used to check if the input is a torch tensor. This implicitly makes `pytorch` a dependency.

This pull request resolve this issue so TorchShow can be used without installing pytorch (in which case it will not handle the `torch.Tensor` but will still work with other types of inputs).