### PR TITLE
Adding PIL and Filename support

### DIFF
--- a/API.md
+++ b/API.md
@@ -21,7 +21,7 @@ torchshow.show(x,
 
 ### Parameters:
 
-* **x**: *tensor-like (support both `torch.Tensor` and `np.ndarray`) or List of tensor-like.* The tensor data that we want to visualize.
+* **x**: *tensor-like (support both `torch.Tensor`, `np.ndarray` and `PIL Image`) or List of tensor-like. * The tensor data that we want to visualize. Filename and list of filenames are also supported, for example: `ts.show("my_image.jpg")`.
 
 * **mode**: *str*. The visualize mode. The default value is `"auto"` where TorchShow will automatically infer the mode. Available options are: `"image"`, `"flow"`, `"grayscale"`, `"categorical_mask"`.
 
@@ -88,7 +88,7 @@ torchshow.show_video(x,
                      dpi=None)
 ```
 
-* **x**: *tensor-like (support both `torch.Tensor` and `np.ndarray`) or List of tensor-like.* The tensor data that we want to visualize.
+* **x**: *tensor-like (Currently support `torch.Tensor`, `np.ndarray`, and `PIL.Image.Image`) or List of tensor-like.* The tensor data that we want to visualize.
 
 * **display**: *bool*. If set to false, TorchShow will not display the data but return the list of processed data. Use it when you want to visualize them using other libraries such as OpenCV.
 

--- a/API.md
+++ b/API.md
@@ -88,7 +88,7 @@ torchshow.show_video(x,
                      dpi=None)
 ```
 
-* **x**: *tensor-like (Currently support `torch.Tensor`, `np.ndarray`, and `PIL.Image.Image`) or List of tensor-like.* The tensor data that we want to visualize.
+* **x**: *tensor-like (Support both `torch.Tensor` and `np.ndarray`) or List of tensor-like.* The tensor data that we want to visualize.
 
 * **display**: *bool*. If set to false, TorchShow will not display the data but return the list of processed data. Use it when you want to visualize them using other libraries such as OpenCV.
 

--- a/changelogs.md
+++ b/changelogs.md
@@ -3,6 +3,8 @@
 ## Next Version
 - Fix bugs when unnormalize with customize mean and std
 - Support specifying the color map for grayscale image. 
+- Support PIL Image.
+- Support passing filenames.
 
 ## [2022-06-30] v0.4.2
 - You can specify the `figsize`, `dpi`, and `subtitle` parameter when calling ts.show(). 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -207,6 +207,26 @@ def test(section):
         test_normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
         test_normalize([0.4851231531212364564, 0.4561231523135436, 0.406123412312452343], [0.2293453455673435, 0.22434531445342, 0.22534534472423])
 
+    ts.set_image_mean([0,0,0])
+    ts.set_image_std([1,1,1])
+
+    if section <=9:
+        print("9 Testing PIL Image")
+        pil_rgb = Image.open("test_data/example_category_mask.png")
+        pil_depth = Image.open("test_data/example_depth.png")
+        ts.show([pil_rgb, pil_depth])
+        ts.save([pil_rgb, pil_depth])
+        
+    if section <=10:
+        print("10 Testing filename as input")
+        ts.show(["test_data/example_image.jpeg", "test_data/example_depth.png", "test_data/example_category_mask.png"])
+        try:
+            ts.show("test_data/a_file_that_does_not_exists.jpg")
+        except Exception as e :
+            print(e)
+            pass
+        ts.show("test_data/example_image_rotated_by_exif.jpeg")
+        ts.show("test_data/example_flow.flo")
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:

--- a/torchshow/utils.py
+++ b/torchshow/utils.py
@@ -1,4 +1,10 @@
 import numpy as np
+import os
+import sys
+import importlib
+import warnings
+
+_EXIF_ORIENT = 274
 
 def isinteger(x):
     """
@@ -38,16 +44,39 @@ def calculate_grid_layout(N, img_H, img_W, nrow=None, ncol=None):
     
 def tensor_to_array(x):
     # Recursively perform tensor to array conversion
+    # ====== PyTorch Tensor =======
     try:
-        import torch # If PyTorch is not installed, TorchShow will not handle torch tensors.
+        torch = import_if_not_yet("torch")
     except ImportError:
         pass
     else:
         if isinstance(x, torch.Tensor):
             return x.detach().clone().cpu().numpy()
-        
+    
+    # ====== PIL Image =======
+    try: 
+        Image = import_if_not_yet(module_name="Image", package_name="PIL")
+    except ImportError:
+        pass
+    else:
+        if isinstance(x, Image.Image):
+            return np.asarray(x)
+    
+    # ====== Numpy Array =======
     if isinstance(x, np.ndarray):
         return x.copy()
+    
+    # ====== Filename =======
+    elif isinstance(x, str): # Handling filename
+        if os.path.exists(x):
+            if x.split('.')[-1].lower() == 'flo': # Handling optical flow files.
+                return read_flow(x)
+            else:
+                image = read_image_PIL(x)
+                return np.asarray(image)
+        else:
+            raise FileNotFoundError(f"{x} is not a file.")
+    # ====== Recursively processing list of inputs
     elif isinstance(x, list):
         return [tensor_to_array(e) for e in x]
     else:
@@ -66,6 +95,72 @@ def isnotebook():
             return False  # Other type (?)
     except NameError:
         return False      # Probably standard Python interpreter
+    
+def import_if_not_yet(module_name, package_name=""):
+    module_key = f"{package_name}.{module_name}".lstrip('.')
+    if module_key not in sys.modules:
+        return importlib.import_module(module_name, package_name)
+    else:
+        return sys.modules[module_key]
+
+def read_image_PIL(filename):
+    try: 
+        Image = import_if_not_yet(module_name="Image", package_name="PIL")
+    except ImportError:
+        raise ImportError("TorchShow opens image files using PIL which is not yet installed.")
+    else:
+        image = Image.open(filename)
+        mode = image.mode
+        if mode == 'RGBA': # Convert RGBA to RGB since torchshow will handle 4 channel images differently.
+            mode = 'RGB'
+            
+        """
+        The following code is for correctly applying the exif orientation. 
+        This code is modified based on https://github.com/facebookresearch/detectron2/blob/2b98c273b240b54d2d0ee6853dc331c4f2ca87b9/detectron2/data/detection_utils.py#L119
+        """
+        
+        if not hasattr(image, "getexif"):
+            return image
+
+        try:
+            exif = image.getexif()
+        except Exception:  # https://github.com/facebookresearch/detectron2/issues/1885
+            exif = None
+
+        if exif is None:
+            return image
+
+        orientation = exif.get(_EXIF_ORIENT)
+        method = {
+            2: Image.FLIP_LEFT_RIGHT,
+            3: Image.ROTATE_180,
+            4: Image.FLIP_TOP_BOTTOM,
+            5: Image.TRANSPOSE,
+            6: Image.ROTATE_270,
+            7: Image.TRANSVERSE,
+            8: Image.ROTATE_90,
+        }.get(orientation)
+
+        if method is not None:
+            warnings.warn(f"TorchShow has detected orientation information in the EXIF of file {filename} and the corresponding transformed has been applied. Please be aware of this issue if you want to load this file with PIL in your code.")
+            image = image.transpose(method)
+            
+        return image.convert(mode)
+
+
+def read_flow(filename):
+    with open(filename, 'rb') as f:
+        magic = np.fromfile(f, np.float32, count=1)
+        if 202021.25 != magic:
+            print('Magic number incorrect. Invalid .flo file')
+        else:
+            w = np.fromfile(f, np.int32, count=1)[0]
+            h = np.fromfile(f, np.int32, count=1)[0]
+            print('Reading %d x %d flo file' % (w, h))
+            data = np.fromfile(f, np.float32, count=2*w*h)
+            # Reshape data into 3D array (columns, rows, bands)
+            data2D = np.resize(data, (h, w, 2))
+        return data2D
 
 
 if __name__ == '__main__':

--- a/torchshow/visualization.py
+++ b/torchshow/visualization.py
@@ -253,6 +253,7 @@ def unnormalize_with_mean_and_std(x, mean, std):
     """
     General Channel-wise mean std unnormalization. Expect input to be (H, W, C)
     """
+    x = x.copy()
     assert (len(x.shape) == 3), "Unnormalization only support (H, W, C) format input, got {}".format(x.shape)
     C = x.shape[-1]
     assert (len(mean) == C) and (len(std) == C), "Number of mean and std values must equals to number of channels."
@@ -378,7 +379,7 @@ def vis_categorical_mask(x, max_N=256, **kwargs):
     cmap = colors.ListedColormap(color_list, N=N)
     
     x = cmap(x.astype(np.int), alpha=None, bytes=True)[:,:,:3]
-    print(x.shape)
+    # print(x.shape)
     plot_cfg = dict( interpolation="nearest")
     
     vis['disp'] = x


### PR DESCRIPTION
1. Adding PIL Image support so `ts.show()` can be directly used on PIL image without converting it to numpy array.
2. Torchshow now allows `filename` and `list of filenames` as inputs. It will try to open the file(s) and visualize them.

Examples:
```python
ts.show(["test_data/example_image.jpeg", "test_data/example_depth.png", "test_data/example_category_mask.png"])
ts.show("test_data/example_flow.flo")
```
