### PR TITLE
change `np.int` to `int` since `np.int` is deprecated

### DIFF
--- a/torchshow/visualization.py
+++ b/torchshow/visualization.py
@@ -416,7 +416,7 @@ def vis_categorical_mask(x, max_N=256, **kwargs):
     
     cmap = colors.ListedColormap(color_list, N=N)
     
-    x = cmap(x.astype(np.int), alpha=None, bytes=True)[:,:,:3]
+    x = cmap(x.astype(int), alpha=None, bytes=True)[:,:,:3]
     # print(x.shape)
     plot_cfg = dict( interpolation="nearest")
     


### PR DESCRIPTION
AttributeError: module 'numpy' has no attribute 'int'
`np.int` is deprecated in numpy 1.24 (https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated)