### PR TITLE
Allow specifying nrows and ncols when visualizing a list of tensors.

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -144,6 +144,20 @@ def test(section):
         ts.show(batch, axes_title="Image ID: {img_id_from_1}")
         ts.show(batch, nrows=4, axes_title="{img_id}-{img_id_from_1}-{row}-{column}")
         ts.show(batch, nrows=4, axes_title="{img_id}-{img_id_from_1}-{row}-{column}", suptitle="Figure 1")
+        
+        print("4.3 List of tensors")
+        list_tensors = list(batch)
+        ts.show(list_tensors)
+        ts.save(list_tensors)
+        ts.show(list_tensors, ncols=3)
+        ts.save(list_tensors, ncols=3)
+        ts.show(list_tensors, nrows=4)
+        ts.save(list_tensors, nrows=4)
+        ts.show(list_tensors, nrows=3, ncols=5)
+        ts.save(list_tensors, nrows=3, ncols=5)
+        ts.show(list_tensors, axes_title="Image ID: {img_id_from_1}")
+        ts.show(list_tensors, nrows=4, axes_title="{img_id}-{img_id_from_1}-{row}-{column}")
+        ts.show(list_tensors, nrows=4, axes_title="{img_id}-{img_id_from_1}-{row}-{column}", suptitle="List of Tensors")
 
     if section <=5:
         print("5.1 Custom Layout")
@@ -165,6 +179,11 @@ def test(section):
         ts.show_video([[video, video2], 
                        [video3]])
         video4 = torch.rand(13,5, 100, 100)
+        list_of_videos = [video, video2, video3, video, video2, video3]
+        ts.show_video(list_of_videos)
+        ts.show_video(list_of_videos, ncols=3)
+        ts.show_video(list_of_videos, nrows=3)
+        ts.show_video(list_of_videos, nrows=2, ncols=8)
         print("6.2 ts.show_video with image") 
         # This test produces unwanted results. Ignore it at this moment unless requested.
         ts.show_video(rgb_img)

--- a/torchshow/torchshow.py
+++ b/torchshow/torchshow.py
@@ -68,8 +68,17 @@ def show(x, display=True, **kwargs):
             raise TypeError("Unsupported shape of numpy array {} .".format(x.shape))
         
     elif isinstance(x, list):
-        if isinstance(x[0], np.ndarray): # if the input is list of images [img1, img2], make it [[img1, img2]]
-            vis_list = [x]
+        if isinstance(x[0], np.ndarray): # if the input is list of images [img1, img2, ....]
+            nrows = kwargs.get('nrows', None)
+            ncols = kwargs.get('ncols', None)
+            if (nrows is not None) or (ncols is not None): # If user specified the grid layout
+                N = len(x)
+                # Here we assume either `nrows` or `ncols` must given so we do not have to specify H, W
+                nrows, ncols = calculate_grid_layout(N, None, None, nrows, ncols)
+                assert (nrows * ncols >= N)
+                vis_list = [list(x[i:i + ncols]) for i in range(0, N, ncols)] # vis_list is now a list of list
+            else:    
+                vis_list = [x] # Make it [[img1, img2, ...]] if `nrows` or `ncols` are not specified
         else:
             vis_list = x
 
@@ -111,8 +120,17 @@ def show_video(x, display=True, **kwargs):
         video_list = [[x]] # for a single video, make it [[vid]]
         
     elif isinstance(x, list):
-        if isinstance(x[0], np.ndarray): # if the input is list of array [vid1, vid2], make it [[vid1, vid2]]
-            video_list = [x]
+        if isinstance(x[0], np.ndarray): # if the input is list of array [vid1, vid2, ...]
+            nrows = kwargs.get('nrows', None)
+            ncols = kwargs.get('ncols', None)
+            if (nrows is not None) or (ncols is not None): # If user specified the grid layout
+                N = len(x)
+                # Here we assume either `nrows` or `ncols` must given so we do not have to specify H, W.
+                nrows, ncols = calculate_grid_layout(N, None, None, nrows, ncols)
+                assert (nrows * ncols >= N)
+                video_list = [list(x[i:i + ncols]) for i in range(0, N, ncols)] # video_list is now a list of list
+            else:    
+                video_list = [x] # Make it [[vid1, vid2, ...]] if `nrows` or `ncols` are not specified
         else:
             video_list = x
             

--- a/torchshow/utils.py
+++ b/torchshow/utils.py
@@ -33,11 +33,11 @@ def calculate_grid_layout(N, img_H, img_W, nrow=None, ncol=None):
     """
     Function to calculate grid_layout
     """
-    if (nrow != None and ncol == None):
+    if (nrow != None): # `nrow` has higher priority than `ncol`.
         ncol = int(np.ceil(N / nrow))
-    elif (nrow == None and ncol != None):
+    elif (ncol != None):
         nrow = int(np.ceil(N / ncol))
-    else:
+    else: # If both nrow and ncols are not set, perform automatic calculation.
         N_sqrt = np.sqrt(N)
         if img_H >= img_W:
             nrow = int(np.floor(N_sqrt))


### PR DESCRIPTION
# Issue
If the input is a list of tensors, TorchShow will visualize it using the custom grid layout. This means that all the tensors in the list will be shown in one row no matter how many tensors are in the list.

```python
x = [img1, img2, img3, img4, img5]
ts.show(x) # All the five images will be in the same rows.
ts.show(x, nrows=3) # The `nrows` parameter will NOT change the layout.
```

# Changes

This PR will make it possible to use `nrows` and `ncols` when dealing with a list of tensors, making it easier to visualize a long list of tensors.

# Example

```python
x = [rand_img1, rand_img2, ...., rand_img8]
ts.show(x, nrows=3)
```

### Previous output
![2023-06-05_23-24-04-425664](https://github.com/xwying/torchshow/assets/23617677/ac927784-4586-4b00-b57c-db37fa33ba90)


### Current output
![2023-06-05_23-24-12-326412](https://github.com/xwying/torchshow/assets/23617677/3320b7f8-f449-4c09-8e62-3dcc23c8f802)
