### PR TITLE
Delete empty axes to prevent unexpected white space in ts.save

### DIFF
--- a/torchshow/visualization.py
+++ b/torchshow/visualization.py
@@ -137,6 +137,11 @@ def display_plt(vis_list, **kwargs):
             title_namespace["column"] = j
             if axes_title is not None:
                 axes[i, j].set_title(axes_title.format(**title_namespace))
+    
+    # Delete empty axes            
+    for ax in axes.ravel():
+        if not ax.has_data():
+            fig.delaxes(ax)
            
     if not show_axis:
         for ax in axes.ravel():
@@ -233,6 +238,11 @@ def animate_plt(video_list, **kwargs):
                 plots.append(plot)
             else:
                 plots.append(None)
+    
+    # Delete empty axes
+    for ax in axes.ravel():
+        if not ax.has_data():
+            fig.delaxes(ax)
     
     if not show_axis:
         for ax in axes.ravel():


### PR DESCRIPTION
## Problem
I notice that sometimes there are still white spaces around the plots when saving figures with grid layout. For example, saving 7 images in a 3x3 grid will leave white space on the bottom right.

## Cause
The cause for this issue is that (using the above case as an example) we create 9 axes (3x3), but only add data to 7 of them, and the remaining 2 axes have uncontrolled size which may extend the size of the figure.

## Solution
Find and delete empty axes after plotting all the data.