### PR TITLE
Modify set_window_title function to avoid version comparison

### DIFF
--- a/changelogs.md
+++ b/changelogs.md
@@ -1,5 +1,8 @@
 # Changelogs
 
+## Master Branch
+- Modify set_window_title function to avoid version comparison bugs ([#24](https://github.com/xwying/torchshow/issues/24)).
+
 ## [2023-07-02] v0.5.1
 - Fix `np.int` depreciation issues ([#13](https://github.com/xwying/torchshow/pull/13)).
 - Allow specifying `nrows` and `ncols` when visualizing a list of tensors ([#17](https://github.com/xwying/torchshow/pull/17)).

--- a/torchshow/visualization.py
+++ b/torchshow/visualization.py
@@ -44,11 +44,14 @@ def set_window_title(fig, title):
     """
     Set the title of the figure window (effective when using a interactive backend.)
     """
-    # fig.canvas.set_window_title(title)
-    if matplotlib.__version__ < '3.4':
+    try:
         fig.canvas.set_window_title(title)
-    else:
-        fig.canvas.manager.set_window_title(title)
+    except:
+        try:
+            fig.canvas.manager.set_window_title(title)
+        except:
+            logger.info("Seting window title failed.")
+    
 
 def imshow(ax, vis, alpha=None, extent=None, show_rich_info=True):
     max_rows, max_cols = vis['raw'].shape[:2]


### PR DESCRIPTION
This pull request fixes the issue #24.

The original problem was caused by version comparison using string, which cannot cover all cases. For example, `"3.4" < "3.10"` will return `False`.

While more precise version comparison is possible via some advanced logic, here we simply replace it with the try-exception blocks. 