### PR TITLE
Support more dtype

### DIFF
--- a/changelogs.md
+++ b/changelogs.md
@@ -2,6 +2,7 @@
 
 ## Master Branch
 - Modify set_window_title function to avoid version comparison bugs ([#24](https://github.com/xwying/torchshow/issues/24)).
+- Support more data dtype for pytorch tensors.
 
 ## [2023-07-02] v0.5.1
 - Fix `np.int` depreciation issues ([#13](https://github.com/xwying/torchshow/pull/13)).

--- a/torchshow/utils.py
+++ b/torchshow/utils.py
@@ -57,7 +57,10 @@ def tensor_to_array(x):
         pass
     else:
         if isinstance(x, torch.Tensor):
-            return x.detach().clone().cpu().numpy()
+            x = x.detach().clone().cpu()
+            if x.dtype in [torch.bfloat16, torch.float16, torch.bool]:
+                x = x.float()
+            return x.numpy()
     
     # ====== PIL Image =======
     try: 

--- a/torchshow/utils.py
+++ b/torchshow/utils.py
@@ -4,9 +4,11 @@ import sys
 import importlib
 import warnings
 import numbers
+import logging
 
 _EXIF_ORIENT = 274
 
+logger = logging.getLogger('TorchShow')
 
 def isnumber(x):
     return isinstance(x, numbers.Number)
@@ -59,6 +61,7 @@ def tensor_to_array(x):
         if isinstance(x, torch.Tensor):
             x = x.detach().clone().cpu()
             if x.dtype in [torch.bfloat16, torch.float16, torch.bool]:
+                logger.warning("The tensor with type \"{}\" was automatically converted to float32 for visualization.".format(x.dtype))
                 x = x.float()
             return x.numpy()
     


### PR DESCRIPTION
This pull request adds automatic conversion for special PyTorch tensors, including torch.float16, torch.bfloat16, and torch.bool.

The issue was first mentioned in #23, as some special dtypes, such as `bfloat16`, do not have a .numpy() method. It seems that PyTorch developers wanted to let users specifically control how they convert these special dtypes; therefore, I had been hesitant to add automatic conversion.

However, it seems that for visualization purposes, we will convert them to `float` most of the time. So, I have finally added the support, and a warning message will be shown when these conversions occur.