### PR TITLE
Matplotlib version specification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'numpy',
-        'matplotlib'],
+        'matplotlib<=3.9'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
I experienced an `FigureCanvasAgg' object has no attribute 'set_window_title'` error while using this package in python 3.10 with matplotlib 3.10. Downgrading matplotlib to 3.9 fixed it.